### PR TITLE
[jjo] feat: add --cleanup_gotemplate=true flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,11 @@ var appFlags = []cli.Flag{
 		Value: "generated",
 		Usage: "output dir",
 	},
+	&cli.BoolFlag{
+		Name:  "cleanup_gotemplate",
+		Value: true,
+		Usage: "remove lines that look like gotemplate",
+	},
 	&cli.StringFlag{
 		Name:  "template_sel",
 		Value: "tpl_flat",
@@ -163,6 +168,7 @@ func handleFile(c *cli.Context, file string) {
 		kind:      c.String("kind_re"),
 		filename:  c.String("file_re"),
 	}
+	cleanupGoTemplate := c.Bool("cleanup_gotemplate")
 
 	tpl, err := template.New("outfile").Parse(outfileTemplate)
 	if err != nil {
@@ -173,7 +179,7 @@ func handleFile(c *cli.Context, file string) {
 
 	for _, fileContent := range files {
 
-		m, err := getYamlInfo(fileContent)
+		m, err := getYamlInfo(fileContent, cleanupGoTemplate)
 		if err != nil {
 			log.Warnf("Ignoring %v", err)
 		}

--- a/yaml.go
+++ b/yaml.go
@@ -7,14 +7,15 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func getYamlInfo(yamlContent string) (*KubernetesAPI, error) {
+func getYamlInfo(yamlContent string, cleanupGoTemplate bool) (*KubernetesAPI, error) {
 
 	// Start by removing all lines with templating in to create sane yaml
 	cleanYaml := ""
 	for _, line := range strings.Split(yamlContent, "\n") {
-		if !strings.Contains(line, "{{") {
-			cleanYaml += line + "\n"
+		if cleanupGoTemplate && strings.Contains(line, "{{") {
+			continue
 		}
+		cleanYaml += line + "\n"
 	}
 
 	var m KubernetesAPI


### PR DESCRIPTION
Add `--cleanup_gotemplate` flag, defaulting to `true` (current behavior).

There are legitimate cases where we'd want to let gotemplate-like
strings in the output files, notably Prometheus' alerting rules,
which support gotemplate'd strings.