### PR TITLE
feat: custom shortname map flag

### DIFF
--- a/kubernetes-resources_test.go
+++ b/kubernetes-resources_test.go
@@ -18,7 +18,34 @@ func Test_getShortName(t *testing.T) {
 	for _, tt := range tests {
 		name := fmt.Sprintf("%s -> %s", tt.have, tt.want)
 		t.Run(name, func(t *testing.T) {
-			if got := getShortName(tt.have); got != tt.want {
+			if got := getShortName(tt.have, nil); got != tt.want {
+				t.Errorf("getShortName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getShortName_CustomMap(t *testing.T) {
+	tests := []struct {
+		name string
+		have string
+		want string
+	}{
+		{have: "ServiceAccount", want: "sa"},
+		{have: "horizontalpodautoscaler", want: "hpa"},
+		{have: "Pod", want: "pod"},
+		{have: "Deployment", want: "dep"},
+	}
+
+	customShortNameMap, err := loadCustomShortnameMapFile("./testdata/custom_sn_map.json")
+	if err != nil {
+		t.Fatalf("Could not load custom shortname map file: %v", err)
+	}
+
+	for _, tt := range tests {
+		name := fmt.Sprintf("%s -> %s", tt.have, tt.want)
+		t.Run(name, func(t *testing.T) {
+			if got := getShortName(tt.have, customShortNameMap); got != tt.want {
 				t.Errorf("getShortName() = %v, want %v", got, tt.want)
 			}
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-
 	"text/template"
 
 	"github.com/google/go-cmp/cmp"
@@ -128,7 +127,7 @@ func Test_outFile(t *testing.T) {
 				namespace: tt.namespaceRe,
 				filename:  tt.fileRe,
 			}
-			got, err := outFile(tt.outdir, tpl, filters, m)
+			got, err := outFile(tt.outdir, tpl, filters, m, nil)
 			if got != tt.fileExp {
 				t.Errorf("outFile() got = '%v', want '%v'", got, tt.fileExp)
 			}
@@ -137,10 +136,8 @@ func Test_outFile(t *testing.T) {
 }
 
 func Test_handleFile(t *testing.T) {
-
 	// determine input files
 	match, err := filepath.Glob("testdata/*.yaml")
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,9 +147,9 @@ func Test_handleFile(t *testing.T) {
 		runTest(t, in, out)
 	}
 }
+
 func runTest(t *testing.T, in, out string) {
 	t.Run(in, func(t *testing.T) {
-
 		f := filepath.Base(in)
 
 		outDir, err := ioutil.TempDir(os.TempDir(), f+"-")
@@ -161,7 +158,7 @@ func runTest(t *testing.T, in, out string) {
 		}
 		defer os.RemoveAll(outDir)
 
-		handleFile(in, outDir, TemplateFlat, &Filters{})
+		handleFile(in, outDir, TemplateFlat, "", &Filters{})
 
 		wantFiles, err := filepath.Glob(filepath.Join(out, "*"))
 		if err != nil {

--- a/testdata/custom_sn_map.json
+++ b/testdata/custom_sn_map.json
@@ -1,0 +1,3 @@
+{
+    "deployment": "dep"
+}


### PR DESCRIPTION
This commit add a new flag 'custom_sn_map' allowing the use of a custom mapping between resources long and short names. It can be useful when the splitted YAML use custom resource definitions not present in the original mapping.

The original mapping is still used by default.